### PR TITLE
Pass environmental variables to cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,34 +5,46 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.3] - 2020-08-12
+
+### Fix
+
+- pass env vars to cli, so plugins can use them
+
 ## [0.2.2] - 2020-06-27
 
 ### Fix
+
 - optimize kubernetes version detecion
 
 ## [0.2.1] - 2020-06-26
 
 ### Fix
+
 - send errors to stderr
 
 ## [0.2.0] - 2020-06-26
 
 ### New
+
 Add support to the `kubectl-wrapper` to automatically download the same binary
 version that the cluster has.
 
 ### Fix
+
 - `kubectl-wrapper` bug that prevented to exec pods
 - control 403 error on github api that prevents listing available releases to
   install
 - fix plenty of bugs that made windows releases unusable
 
 ### Other
+
 - add specific integration tests for MacOs and Windows
 
 ## [0.1.1] - 2020-06-18
 
 ### Fix
+
 Switch to syscall package to allow using kubectl with a tty support.
 
 ## [0.1.0] - 2020-05-17
@@ -54,11 +66,12 @@ Bump release. Nothing special, but we could use a first real release.
 
 ### Changed
 
-- Change the wrapper scripts of `kubectl` and  `helm` by a binary
+- Change the wrapper scripts of `kubectl` and `helm` by a binary
   - This will make it more maintenable with multiple OS
 - Change the organization of the packages:
   - Leave `cmd` for the binaries
   - The old `cmd` goes to `internal/cmd` as it really is a package
 
 ### CI
+
 - Unify the release workflow with the tests

--- a/internal/wrapper/main.go
+++ b/internal/wrapper/main.go
@@ -85,6 +85,7 @@ func Wrapper(binName string) { // nolint: funlen
 	bin += fileExt
 
 	cmd := exec.Command(bin, os.Args[1:]...)
+	cmd.Env = os.Environ()
 	cmd.Stdout = os.Stdout
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
This way, aws-iam-authenticator, for example, will be able to get it's
aws variables