### PR TITLE
Fix panic when kubeconfig is not valid

### DIFF
--- a/internal/helpers/kube_client.go
+++ b/internal/helpers/kube_client.go
@@ -56,7 +56,7 @@ func KubeGetVersion() (string, error) {
 
 	config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
-		fmt.Println(err)
+		fmt.Println(fmt.Errorf("kbenv failed to load kubeconfig: %w", err))
 		os.Exit(1)
 	}
 	config.Timeout = 1 * time.Second

--- a/internal/helpers/kube_client.go
+++ b/internal/helpers/kube_client.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"flag"
+	"fmt"
 	"io/ioutil"
 	"net/http"
 	"os"
@@ -53,7 +54,11 @@ func KubeGetVersion() (string, error) {
 		return version, nil
 	}
 
-	config, _ = clientcmd.BuildConfigFromFlags("", kubeconfig)
+	config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
 	config.Timeout = 1 * time.Second
 
 	client, err := kubernetes.NewForConfig(config)


### PR DESCRIPTION
If the kubeconfig is invalid for some reason (misconfigured, typo, etc.), currently kbenv will panic with a stacktrace that doesn't really say what's gone wrong. At the very least, we can handle the underlying error and exit to avoid the stacktrace.

Before:
```
$ kubectl get pod
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x1e0 pc=0x1c89b0f]

goroutine 1 [running]:
github.com/little-angry-clouds/kubernetes-binaries-managers/internal/helpers.KubeGetVersion(0xc0000b762c, 0x4, 0x1ef5168, 0x1)
	/private/tmp/kbenv-20210729-90323-1ezpqxa/kubernetes-binaries-managers-0.2.6/internal/helpers/kube_client.go:57 +0x10f
github.com/little-angry-clouds/kubernetes-binaries-managers/internal/wrapper.Wrapper(0x1e64889, 0x7)
	/private/tmp/kbenv-20210729-90323-1ezpqxa/kubernetes-binaries-managers-0.2.6/internal/wrapper/main.go:61 +0x77f
main.main()
	/private/tmp/kbenv-20210729-90323-1ezpqxa/kubernetes-binaries-managers-0.2.6/cmd/kubectl-wrapper/main.go:10 +0x36
```

After:
```
$ ./kubectl-wrapper get pod
kbenv failed to load kubeconfig: invalid configuration: no configuration has been provided
```