### PR TITLE
Update Ubuntu version used within github actions

### DIFF
--- a/.github/workflows/generic-tests.yml
+++ b/.github/workflows/generic-tests.yml
@@ -5,7 +5,7 @@ on: [pull_request_target]
 
 jobs:
   unit-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Set up Go 1.18
         uses: actions/setup-go@v1
@@ -20,7 +20,7 @@ jobs:
         run: make unit-test
 
   static:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Set up Go 1.18
         uses: actions/setup-go@v1

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -5,7 +5,7 @@ on: [pull_request_target]
 
 jobs:
   int-test:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Set up Go 1.18
         uses: actions/setup-go@v1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   release:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Set up Go 1.18
         uses: actions/setup-go@v1


### PR DESCRIPTION
This is due to:

> The Ubuntu-20.04 brownout takes place from 2025-02-01. For more details, see https://github.com/actions/runner-images/issues/11101
